### PR TITLE
config.cpp: Alter option "home"→"PhoneMemoryFolder"

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -29,5 +29,5 @@ void Config::removeConfig(QString data1)
 
 QString Config::getHome()
 {
-    return readConfig("home", "/home/defaultuser");
+    return readConfig("PhoneMemoryFolder", "/home/defaultuser");
 }


### PR DESCRIPTION

… in the settings file `~/.config/cepiperez/fileboxplus.conf` in the `[General]` section, because that is what it is called at the GUI, more self-explanatory and in-line with extant option names.
This still leaves the ToDo open to implement a GUI option for setting this settings option in FileCase's settings page.